### PR TITLE
[User]画像がない場合の詳細表示バグ修正

### DIFF
--- a/resources/views/admin-product-show.blade.php
+++ b/resources/views/admin-product-show.blade.php
@@ -62,6 +62,13 @@
                                 </div>
                             </div>
                         </article>
+                    @else
+                        <!-- デフォルト画像を表示 -->
+                        <article class="img_content">
+                            <div class="img_1">
+                                <div id="mainImage" style="background-image: url('{{ asset('storage/images/default-image.png') }}')"></div>
+                            </div>
+                        </article>
                     @endif
                 </div>
 


### PR DESCRIPTION
User側で画像の投稿がない場合、詳細を表示した際に画像が表示されないというバグを修正しました。